### PR TITLE
Add ESLint and Prettier setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,8 @@
   ],
   "devDependencies": {
     "turbo": "^2.5.4",
-    "tsup": "^8.5.0"
-  }
-=======
-    "eslint": "^9.28.0",
+    "tsup": "^8.5.0",
+    "eslint": "^8.57.0",
     "prettier": "^3.5.3"
   },
   "packageManager": "pnpm@9.15.4"


### PR DESCRIPTION
## Summary
- add ESLint 8 and Prettier to devDependencies
- keep lint/format scripts for monorepo packages
- provide repo-level ESLint and Prettier configurations

## Testing
- `pnpm install`
- `pnpm lint` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_684877943ba0832a9093bc4af6984524