### PR TITLE
Add Next.js i18n skeleton

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,11 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  i18n: {
+    // Default locale used when visiting non-locale prefixed paths
+    defaultLocale: 'en',
+    // Array of supported locales
+    locales: ['en'],
+  },
+};
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- add an i18n skeleton to the web app's Next.js config

## Testing
- `pnpm lint` *(fails: Invalid package.json)*
- `pnpm format` *(fails: Invalid package.json)*
- `pnpm test` *(fails: Invalid package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68487f354f54832a9825f6eee1ad47d2