### PR TITLE
Fix scraper lint and typings

### DIFF
--- a/packages/scraper/src/index.test.ts
+++ b/packages/scraper/src/index.test.ts
@@ -9,12 +9,12 @@ describe('fetchTranscript', () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => [{ transcript: 'hello', metadata: { title: 't' } }]
-    } as any);
-    (global as any).fetch = mockFetch;
+    } as unknown as { ok: boolean; json: () => Promise<unknown> });
+    (global as unknown as { fetch: jest.Mock }).fetch = mockFetch;
   });
 
   afterEach(() => {
-    (global as any).fetch = oldFetch;
+    (global as unknown as { fetch: typeof mockFetch }).fetch = oldFetch as typeof mockFetch;
     mockFetch.mockReset();
   });
 

--- a/packages/scraper/src/index.ts
+++ b/packages/scraper/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 export class Scraper {
   scrape(url: string): string {
     return `Scraping ${url}`;


### PR DESCRIPTION
## Summary
- remove global eslint disable from scraper index
- type mocked fetch response in scraper test

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6848926b1214832a82879926c02bc567