### PR TITLE
Unify ESLint version

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,6 @@
     "postcss": "^8.5.4",
     "tailwindcss": "^4.1.8",
     "typescript": "^5.2.2",
-    "eslint": "^8.57.0"
+    "eslint": "^8.57.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@playwright/test": "^1.41.2",
     "@types/jest": "^29.5.2",
-    "eslint": "^9.28.0",
+    "eslint": "^8.57.1",
     "jest": "^29.7.0",
     "prettier": "^3.5.3",
     "ts-jest": "^29.1.1",

--- a/packages/core-ai/package.json
+++ b/packages/core-ai/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --write ."
   },
   "devDependencies": {
-    "eslint": "^8.57.0"
+    "eslint": "^8.57.1"
   }
 }
 

--- a/packages/scraper/package.json
+++ b/packages/scraper/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --write ."
   },
   "devDependencies": {
-    "eslint": "^8.57.0"
+    "eslint": "^8.57.1"
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         specifier: ^6.7.0
         version: 6.21.0(eslint@8.57.1)(typescript@5.8.3)
       eslint:
-        specifier: ^8.57.0
+        specifier: ^8.57.1
         version: 8.57.1
       jest:
         specifier: ^29.7.0
@@ -61,7 +61,7 @@ importers:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.4)
       eslint:
-        specifier: ^8.57.0
+        specifier: ^8.57.1
         version: 8.57.1
       postcss:
         specifier: ^8.5.4
@@ -76,13 +76,13 @@ importers:
   packages/core-ai:
     devDependencies:
       eslint:
-        specifier: ^8.57.0
+        specifier: ^8.57.1
         version: 8.57.1
 
   packages/scraper:
     devDependencies:
       eslint:
-        specifier: ^8.57.0
+        specifier: ^8.57.1
         version: 8.57.1
 
 packages:


### PR DESCRIPTION
## Summary
- use ESLint 8.57.1 across all packages
- regenerate pnpm-lock.yaml

## Testing
- `pnpm install`
- `npx jest -c jest.config.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_684892b0556c832a94a80c37c29f4f99