### PR TITLE
Fix Response casting in scraper test

### DIFF
--- a/packages/scraper/src/index.test.ts
+++ b/packages/scraper/src/index.test.ts
@@ -9,12 +9,12 @@ describe('fetchTranscript', () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => [{ transcript: 'hello', metadata: { title: 't' } }]
-    } as unknown as { ok: boolean; json: () => Promise<unknown> });
+    } as unknown as Response);
     (global as unknown as { fetch: jest.Mock }).fetch = mockFetch;
   });
 
   afterEach(() => {
-    (global as unknown as { fetch: typeof mockFetch }).fetch = oldFetch as typeof mockFetch;
+    (global as unknown as { fetch: jest.Mock }).fetch = oldFetch as typeof mockFetch;
     mockFetch.mockReset();
   });
 


### PR DESCRIPTION
## Summary
- update scraper test casts to use `Response`

## Testing
- `corepack enable`
- `corepack prepare pnpm@9.15.4 --activate`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6848981f4770832a82674d4f7b0c98ca