### PR TITLE
Add global Prettier ignore file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,16 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+.next/
+dist/
+build/
+out/
+
+# Turbo cache and coverage
+.turbo/
+coverage/
+test-results/
+
+# Playwright reports
+playwright-report/


### PR DESCRIPTION
## Summary
- create a `.prettierignore` file to skip compiled output

## Testing
- `pnpm install`
- `pnpm format` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6848a0462604832a85905bb6d322900a