### PR TITLE
Add env placeholders for Sentry and DeepSeek

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 # External service credentials
 OPENROUTER_API_KEY=your-openrouter-api-key
 APIFY_TOKEN=your-apify-token
+SENTRY_DSN=your-sentry-dsn
+DEEPSEEK_API_KEY=your-deepseek-api-key
 
 # Upstash Redis configuration
 UPSTASH_REDIS_REST_URL=https://your-upstash-instance.upstash.io

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The workspace is managed with **pnpm** and **Turborepo**.
    - `SUPABASE_SERVICE_ROLE_KEY`
    - `OPENROUTER_API_KEY`
    - `APIFY_TOKEN`
+   - `SENTRY_DSN`
+   - `DEEPSEEK_API_KEY`
    - `UPSTASH_REDIS_REST_URL`
    - `UPSTASH_REDIS_REST_TOKEN`
 2. Install dependencies:


### PR DESCRIPTION
## Summary
- add `SENTRY_DSN` and `DEEPSEEK_API_KEY` to `.env.example`
- list new environment variables in README

## Testing
- `pnpm lint` *(fails: turbo could not fetch packages)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6848a0491ab8832ab0704fddddcfb040