### PR TITLE
Update Jest scripts for packages

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx -c ../../.eslintrc.cjs",
     "format": "prettier --write .",
-    "test": "jest"
+    "test": "jest --config ../../jest.config.js --passWithNoTests"
   },
   "dependencies": {
     "next": "14.0.0",

--- a/packages/core-ai/package.json
+++ b/packages/core-ai/package.json
@@ -7,7 +7,7 @@
     "build": "tsup src/index.ts --dts --tsconfig ./tsconfig.json",
     "lint": "eslint . --ext .ts,.js -c ../../.eslintrc.cjs",
     "format": "prettier --write .",
-    "test": "jest"
+    "test": "jest --config ../../jest.config.js --passWithNoTests"
   },
   "devDependencies": {
     "eslint": "^8.57.1"

--- a/packages/scraper/package.json
+++ b/packages/scraper/package.json
@@ -7,7 +7,7 @@
     "build": "tsup src/index.ts --dts --tsconfig ./tsconfig.json",
     "lint": "eslint . --ext .ts,.js -c ../../.eslintrc.cjs",
     "format": "prettier --write .",
-    "test": "jest"
+    "test": "jest --config ../../jest.config.js --passWithNoTests"
   },
   "devDependencies": {
     "eslint": "^8.57.1"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,12 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["esnext"],
-    "types": ["node"]
+    "lib": [
+      "esnext"
+    ],
+    "types": [
+      "node",
+      "jest"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- run tests via ts-jest in packages and web app
- include Jest types in TypeScript config

## Testing
- `pnpm install`
- `NODE_OPTIONS=--dns-result-order=ipv4first pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6848af53bc28832a920c8904bf2a4478