### PR TITLE
Implement Supabase magic link auth and usage tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The workspace is managed with **pnpm** and **Turborepo**.
    - `DEEPSEEK_API_KEY`
    - `UPSTASH_REDIS_REST_URL`
    - `UPSTASH_REDIS_REST_TOKEN`
+
 2. Install dependencies:
    ```bash
    pnpm install
@@ -56,6 +57,12 @@ The workspace is managed with **pnpm** and **Turborepo**.
    This runs `turbo dev`, which executes each workspace's `dev` script concurrently.
 
 These commands will evolve as the monorepo grows, but they provide a basic workflow for now.
+
+### Authentication
+
+The web app uses **Supabase Auth**. Visit `/login` and enter your email to
+receive a magic link. The API expects the `Authorization` header with the
+Supabase access token when making requests.
 
 ## Development
 

--- a/apps/web/app/api/ingest/route.ts
+++ b/apps/web/app/api/ingest/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { incrementUsage } from '../../../lib/usage';
+
+const supabaseAdmin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+);
+
+export async function POST(req: NextRequest) {
+  const authHeader = req.headers.get('authorization');
+  if (!authHeader) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const token = authHeader.replace('Bearer ', '');
+  const {
+    data: { user },
+    error,
+  } = await supabaseAdmin.auth.getUser(token);
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const usage = await incrementUsage(user.id);
+  if (usage > 3) {
+    return NextResponse.json({ error: 'Daily limit reached' }, { status: 429 });
+  }
+
+  const { url } = await req.json();
+  return NextResponse.json({ message: `Ingested ${url}`, usage });
+}

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+import { useState } from 'react';
+import { supabase } from '../../lib/supabaseClient';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: window.location.origin },
+    });
+    if (error) {
+      setMessage(error.message);
+    } else {
+      setMessage('Check your email for the magic link.');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+        placeholder="Email"
+        className="border p-2"
+      />
+      <button type="submit" className="px-4 py-2 bg-blue-600 text-white">
+        Send Magic Link
+      </button>
+      {message && <p>{message}</p>}
+    </form>
+  );
+}

--- a/apps/web/lib/supabaseClient.ts
+++ b/apps/web/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+);

--- a/apps/web/lib/usage.ts
+++ b/apps/web/lib/usage.ts
@@ -1,0 +1,24 @@
+import { Redis } from '@upstash/redis';
+
+const redis = new Redis({
+  url: process.env.UPSTASH_REDIS_REST_URL!,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+
+const PREFIX = 'daily_usage:';
+
+function key(userId: string) {
+  const date = new Date().toISOString().split('T')[0];
+  return `${PREFIX}${userId}:${date}`;
+}
+
+export async function incrementUsage(userId: string): Promise<number> {
+  const usage = await redis.incr(key(userId));
+  await redis.expire(key(userId), 60 * 60 * 24);
+  return usage as number;
+}
+
+export async function getUsage(userId: string): Promise<number> {
+  const usage = await redis.get<number>(key(userId));
+  return usage ?? 0;
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,9 @@
   "dependencies": {
     "next": "14.0.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "@supabase/supabase-js": "^2.39.7",
+    "@upstash/redis": "^1.26.0"
   },
   "devDependencies": {
     "@types/node": "^20.8.0",


### PR DESCRIPTION
## Summary
- enable magic link sign-in via Supabase
- add API route to track daily usage with Upstash and block after 3 videos
- update README with authentication notes

## Testing
- `npx prettier --write apps/web/app/login/page.tsx apps/web/lib/supabaseClient.ts apps/web/lib/usage.ts apps/web/app/api/ingest/route.ts README.md apps/web/package.json`
- `pnpm dlx turbo run lint` *(fails: ENETUNREACH)*
- `pnpm dlx turbo run test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6848b26d22c4832a93d280d0ee5bc8f1