### PR TITLE
Add OpenRouter summarization and embedding utilities

### DIFF
--- a/packages/core-ai/src/index.test.ts
+++ b/packages/core-ai/src/index.test.ts
@@ -1,6 +1,63 @@
 /* eslint-disable */
-import { coreAiPlaceholder } from './index';
+import {
+  coreAiPlaceholder,
+  summarizeTranscript,
+  generateEmbedding,
+} from './index';
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
 
 test('coreAiPlaceholder returns core-ai', () => {
   expect(coreAiPlaceholder()).toBe('core-ai');
+});
+
+test('summarizeTranscript uses OpenRouter when available', async () => {
+  const fetchMock = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ choices: [{ message: { content: 'summary' } }] }),
+  });
+  global.fetch = fetchMock as any;
+  process.env.OPENROUTER_API_KEY = 'key';
+
+  const summary = await summarizeTranscript('hello');
+  expect(summary).toBe('summary');
+  expect(fetchMock).toHaveBeenCalledWith(
+    expect.stringContaining('openrouter'),
+    expect.any(Object),
+  );
+});
+
+test('summarizeTranscript falls back to DeepSeek', async () => {
+  const fetchMock = jest
+    .fn()
+    .mockRejectedValueOnce(new Error('fail'))
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'ds' } }] }),
+    });
+  global.fetch = fetchMock as any;
+  process.env.OPENROUTER_API_KEY = 'key';
+  process.env.DEEPSEEK_API_KEY = 'dkey';
+
+  const summary = await summarizeTranscript('hello');
+  expect(summary).toBe('ds');
+  expect(fetchMock.mock.calls[1][0]).toContain('deepseek');
+});
+
+test('generateEmbedding fetches embedding', async () => {
+  const fetchMock = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ data: [{ embedding: [1, 2, 3] }] }),
+  });
+  global.fetch = fetchMock as any;
+  process.env.OPENROUTER_API_KEY = 'key';
+
+  const result = await generateEmbedding('hi');
+  expect(result).toEqual([1, 2, 3]);
+  expect(fetchMock).toHaveBeenCalledWith(
+    expect.stringContaining('embeddings'),
+    expect.any(Object),
+  );
 });

--- a/packages/core-ai/src/index.ts
+++ b/packages/core-ai/src/index.ts
@@ -1,3 +1,120 @@
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+interface ChatCompletionResponse {
+  choices: { message?: { content?: string } }[];
+}
+
+/**
+ * Summarize a transcript using OpenRouter. If the request fails, fall back to
+ * DeepSeek. Both services follow the OpenAI-compatible chat completion API.
+ *
+ * Environment variables:
+ * - OPENROUTER_API_KEY
+ * - DEEPSEEK_API_KEY
+ */
+export async function summarizeTranscript(transcript: string): Promise<string> {
+  const systemPrompt =
+    'You are a helpful assistant that summarizes transcripts in a concise manner.';
+  const messages: ChatMessage[] = [
+    { role: 'system', content: systemPrompt },
+    {
+      role: 'user',
+      content: `Summarize the following transcript:\n${transcript}`,
+    },
+  ];
+
+  const openrouterKey = process.env.OPENROUTER_API_KEY;
+  if (openrouterKey) {
+    try {
+      const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${openrouterKey}`,
+        },
+        body: JSON.stringify({
+          model: 'openai/gpt-3.5-turbo',
+          messages,
+        }),
+      });
+
+      if (res.ok) {
+        const data = (await res.json()) as ChatCompletionResponse;
+        const summary = data.choices?.[0]?.message?.content?.trim();
+        if (summary) return summary;
+      } else {
+        throw new Error(`OpenRouter failed: ${res.status}`);
+      }
+    } catch (err) {
+      console.error('OpenRouter summarization failed:', err);
+    }
+  }
+
+  const deepseekKey = process.env.DEEPSEEK_API_KEY;
+  if (!deepseekKey) {
+    throw new Error('DEEPSEEK_API_KEY is not set');
+  }
+
+  const dsRes = await fetch('https://api.deepseek.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${deepseekKey}`,
+    },
+    body: JSON.stringify({
+      model: 'deepseek-chat',
+      messages,
+    }),
+  });
+
+  if (!dsRes.ok) {
+    throw new Error(`DeepSeek failed: ${dsRes.status}`);
+  }
+
+  const dsData = (await dsRes.json()) as ChatCompletionResponse;
+  const summary = dsData.choices?.[0]?.message?.content?.trim();
+  if (!summary) {
+    throw new Error('No summary returned from DeepSeek');
+  }
+  return summary;
+}
+
+/**
+ * Generate an embedding using the `openai-embedding-3` model via OpenRouter.
+ */
+export async function generateEmbedding(text: string): Promise<number[]> {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    throw new Error('OPENROUTER_API_KEY is not set');
+  }
+
+  const res = await fetch('https://openrouter.ai/api/v1/embeddings', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'openai/embedding-3-small',
+      input: text,
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Embedding request failed: ${res.status}`);
+  }
+
+  const data = (await res.json()) as { data?: { embedding?: number[] }[] };
+  const embedding = data.data?.[0]?.embedding;
+  if (!embedding) {
+    throw new Error('No embedding returned');
+  }
+  return embedding;
+}
+
 export function coreAiPlaceholder() {
   return 'core-ai';
 }

--- a/packages/core-ai/tsconfig.json
+++ b/packages/core-ai/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "include": ["src"],
+  "compilerOptions": {
+    "types": ["node", "jest"]
+  }
 }

--- a/packages/scraper/tsconfig.json
+++ b/packages/scraper/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "include": ["src"],
+  "compilerOptions": {
+    "types": ["node", "jest"]
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["esnext"],
-    "types": ["node"]
+    "types": ["node", "jest"]
   }
 }


### PR DESCRIPTION
## Summary
- implement transcript summarization using OpenRouter with DeepSeek fallback
- add embedding generation using openai-embedding-3 model
- expose new utilities and unit tests
- include Jest types in tsconfigs for testing

## Testing
- `pnpm exec prettier --write packages/core-ai/src/index.ts packages/core-ai/src/index.test.ts`
- `pnpm exec eslint packages/core-ai/src/index.ts packages/core-ai/src/index.test.ts`
- `pnpm exec jest`


------
https://chatgpt.com/codex/tasks/task_e_6848b26a51f0832abe52c01c9259f972