### PR TITLE
Fix duplicate dependency in apps/web

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,9 +14,8 @@
     "next": "14.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@sentry/nextjs": "7.91.0"
-    "@supabase/supabase-js": "^2.39.7",
-    "@upstash/redis": "^1.26.0"
+    "@sentry/nextjs": "7.91.0",
+    "@upstash/redis": "^1.26.0",
     "@supabase/supabase-js": "^2.39.8"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- fix invalid package.json syntax in apps/web
- remove duplicate `@supabase/supabase-js` dependency

## Testing
- `pnpm lint` *(fails: turbo not found)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848cf4ca9a8832a8f1b80fd909e3cbf